### PR TITLE
SIEW-234: Fixed layout on news page

### DIFF
--- a/assets/source/sass/layout/_main-content.scss
+++ b/assets/source/sass/layout/_main-content.scss
@@ -41,10 +41,16 @@
 	   color: #777;
     }
 
-    .news-article ol {
-        margin-left: 0px;
-        padding-left: 0px;
+    .news-article {
+        ol {
+            margin-left: 0px;
+            padding-left: 0px;
+        }
+        .breadcrumbs-wrapper {
+            padding-left: 10px; // makes up for lost padding when only having two content containers in single.blade grid.
+        }
     }
+
 
     .section-page {
 	   h1 {

--- a/views/single.blade.php
+++ b/views/single.blade.php
@@ -5,10 +5,8 @@
 <div class="container main-container news-article">
 
     <div class="grid">
+        @include('partials.breadcrumbs')
         <div class="grid-md-12 grid-lg-9">
-            
-            @include('partials.breadcrumbs')
-            
             @if (is_single() && is_active_sidebar('content-area-top'))
                 <div class="grid sidebar-content-area sidebar-content-area-top">
                     <?php dynamic_sidebar('content-area-top'); ?>


### PR DESCRIPTION
The right aside element should now align with the centered grid content. Make sure that article pages, section pages etc are not broken by the change in html markup or any new style rules. 