### PR TITLE
SIEW-184: Overridden media query rule for right aside in news articles

### DIFF
--- a/assets/source/sass/layout/_main-content.scss
+++ b/assets/source/sass/layout/_main-content.scss
@@ -49,6 +49,11 @@
         .breadcrumbs-wrapper {
             padding-left: 10px; // makes up for lost padding when only having two content containers in single.blade grid.
         }
+        @media screen and #{$screen-below-lg} {
+            .sidebar-right-sidebar {
+                display: flex !important;
+            }
+        }
     }
 
 


### PR DESCRIPTION
Make sure that the right aside container does not dissapear on changed screen size anymore. Check standard pages, section pages, article pages and make sure this change has not broken styling in any of those pages. 