### PR TITLE
SIEW-240: Fixed padding on breadcrumbs and header for archive pages.

### DIFF
--- a/assets/source/sass/layout/_main-content.scss
+++ b/assets/source/sass/layout/_main-content.scss
@@ -56,6 +56,16 @@
         }
     }
 
+    .archive-page {
+        ol {
+            margin-left: 0px;
+            padding-left: 0px;
+        }
+        h1 {
+            padding-left: 15px;
+        }
+    }
+
 
     .section-page {
 	   h1 {

--- a/views/archive.blade.php
+++ b/views/archive.blade.php
@@ -1,8 +1,8 @@
 @extends('templates.master')
 
 @section('content')
-<div class="container main-container">
-    @include('partials.breadcrumbs')
+<div class="container main-container archive-page">
+  @include('partials.breadcrumbs')
 
   <div class="grid">
     <?php


### PR DESCRIPTION
Go to a page like service messages or news archives. Make sure that alignment of breadcrumbs, header and main content is ok. 