### PR TITLE
Feature/nojira linter fixes

### DIFF
--- a/assets/source/js/theme/helpers.js
+++ b/assets/source/js/theme/helpers.js
@@ -57,7 +57,8 @@ export default class Helpers {
                     return result;
                 }
 
-                return this.delayedInvokation(() => this.tryInvoke(func, tryInterval, maximumTries, (currentTry + 1)),
+                return this.delayedInvokation(
+                    () => this.tryInvoke(func, tryInterval, maximumTries, (currentTry + 1)),
                     tryInterval);
             }).catch((reason) => {
                 console.error(reason);

--- a/assets/source/js/theme/helpers.js
+++ b/assets/source/js/theme/helpers.js
@@ -59,7 +59,8 @@ export default class Helpers {
 
                 return this.delayedInvokation(
                     () => this.tryInvoke(func, tryInterval, maximumTries, (currentTry + 1)),
-                    tryInterval);
+                    tryInterval,
+                );
             }).catch((reason) => {
                 console.error(reason);
             });

--- a/assets/source/js/theme/helpers.js
+++ b/assets/source/js/theme/helpers.js
@@ -9,7 +9,7 @@ export default class Helpers {
      * @return {boolean} true if the element was visible and could be focused,
      * otherwise false
      */
-    focusElement(selector) {
+    static focusElement(selector) {
         const jqueryElement = $(selector);
         const isVisible = $(jqueryElement).is(':visible');
 
@@ -28,7 +28,7 @@ export default class Helpers {
      * @return {Promise} A promise which resolves to the function result after
      * it has completed its execution
      */
-    delayedInvokation(func, delay) {
+    static delayedInvokation(func, delay) {
         return new Promise((resolve) => {
             setTimeout(() => resolve(func()), delay);
         });

--- a/assets/source/sass/component/news-grid/news-grid.scss
+++ b/assets/source/sass/component/news-grid/news-grid.scss
@@ -80,7 +80,6 @@
                 padding-bottom: 0em;
                 padding-left: 0.55em;
             } 
-            
         }
     }
 
@@ -126,7 +125,6 @@
                 padding: 5px 40px 5px 40px;
             }
         }
-        
         @media screen and #{$screen-below-md} {
             position: relative;
             padding-bottom: 15%;

--- a/assets/source/sass/component/news-grid/news-grid.scss
+++ b/assets/source/sass/component/news-grid/news-grid.scss
@@ -79,7 +79,7 @@
             @media screen and #{$screen-md-up} {
                 padding-bottom: 0em;
                 padding-left: 0.55em;
-            } 
+            }
         }
     }
 

--- a/assets/source/sass/layout/_header.scss
+++ b/assets/source/sass/layout/_header.scss
@@ -342,7 +342,7 @@ nav {
 #nav-search {
     visibility: hidden;
     @media screen and #{$screen-below-md} {
-	visibility: visible;
+        visibility: visible;
     }
 }
 


### PR DESCRIPTION
Fixed 2 linter errors that has to be reviewed: 
Added static keyword to two methods that do not use the this keyword. I think this should be safe but I'm not sure and as we have no tests I would like a second opinion.

Refrained from fixing 2 linter errors that I would like feedback on:
1. in assets/source/js/admin/load.js - Two errors that want to disallow certain languague features, in this case a for loop. I am not comfortable rewriting this without tests as I cannot justify the risk. Please take a look and then we can think about either changing the linter rules or rewriting.

2. in assets/source/js/theme/helpers.js - One warning about using console.error(). I think this rule is valuable when testing is used instead of logs but perhaps overkill if we don't have testing set up?