### PR TITLE
SIEW-258 Added bg color to comment input field

### DIFF
--- a/assets/source/sass/layout/_main-content.scss
+++ b/assets/source/sass/layout/_main-content.scss
@@ -41,6 +41,10 @@
         color: #777;
     }
 
+    .comment-form-comment {
+        background-color: #fff; // Only affects upphandlingsbloggen since comments are disabled on main site.
+    }
+
     .news-article {
         ol {
             margin-left: 0px;


### PR DESCRIPTION
Could not test this since upphandlingsbloggen only exists live in production. I chose main-content since all the comment specific selectors came from hbg-prime which I think is the original theme from Helsingborg.