### PR TITLE
NOJIRA Add manual loader for Kirki

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,9 +2,16 @@
 
 define('SIMRISHAMN_PATH', get_stylesheet_directory());
 
+$vendor = realpath(dirname(ABSPATH) . '/vendor');
+
 // Include vendor files.
-if (file_exists(dirname(ABSPATH) . '/vendor/autoload.php')) {
-    include_once dirname(ABSPATH) . '/vendor/autoload.php';
+if (file_exists("$vendor/autoload.php")) {
+    include_once "$vendor/autoload.php";
+}
+
+// FIXME: Kirki must be loaded manually.
+if (file_exists("$vendor/aristath/kirki/kirki.php")) {
+    include_once "$vendor/aristath/kirki/kirki.php";
 }
 
 // Initialize class loader.
@@ -12,6 +19,10 @@ require_once SIMRISHAMN_PATH . '/library/Vendor/Psr4ClassLoader.php';
 $loader = new SIMRISHAMN\Vendor\Psr4ClassLoader();
 $loader->addPrefix('Simrishamn', SIMRISHAMN_PATH . '/library');
 $loader->register();
+
+// Clean global namespace.
+unset($vendor);
+unset($loader);
 
 // Run app class.
 new Simrishamn\App();


### PR DESCRIPTION
It seems Kirki doesn't initialize when we include it from _our_ vendor directory. We've been trying to make sure we don't mix-and-match dependency versions, hence why we've disabled the bundled dependencies from Municipio. However, this currently breaks clean builds.

We should look into this more. For now, make sure we Kirki is always initialized.