### PR TITLE
SIEW-288 Remove babel-polyfill imports

### DIFF
--- a/assets/source/js/admin.js
+++ b/assets/source/js/admin.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill';
-
 import load from './admin/load';
 
 window.addEventListener('load', load);

--- a/assets/source/js/theme.js
+++ b/assets/source/js/theme.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import './content/header';
 import Helpers from './theme/helpers';
 

--- a/assets/source/js/theme.js
+++ b/assets/source/js/theme.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import './content/header';
 import Helpers from './theme/helpers';
 


### PR DESCRIPTION
Polyfill is included in WordPress by default as of version 5.0