### PR TITLE
SIEW-309 Fixes issue with htmlchars in titles

### DIFF
--- a/library/Theme/Template.php
+++ b/library/Theme/Template.php
@@ -15,6 +15,9 @@ class Template
         add_filter('Municipio/controller/base/view_data', [$this, 'getFooterData']);
         add_filter('accessibility_items', [$this, 'removePrint'], 20);
         add_action('admin_init', [$this, 'removeContentEditor']);
+
+        // Fix for htmlchars in titles
+        remove_filter('the_title', 'wptexturize');
     }
 
     /**

--- a/library/Theme/Template.php
+++ b/library/Theme/Template.php
@@ -18,6 +18,7 @@ class Template
 
         // Fix for htmlchars in titles
         remove_filter('the_title', 'wptexturize');
+        remove_filter('the_title', 'convert_chars');
     }
 
     /**


### PR DESCRIPTION
This filter mixed with convert_chars seems to be the root cause. Should be safe to disable alone.

https://codex.wordpress.org/Function_Reference/wptexturize