### PR TITLE
Apply linter fixes

### DIFF
--- a/custom-modules/ActionCard/ActionCard.php
+++ b/custom-modules/ActionCard/ActionCard.php
@@ -5,37 +5,34 @@ namespace Simrishamn\ActionCard;
 use \Simrishamn\Theme\CustomModuleHelper;
 
 class ActionCard extends \Modularity\Module
-{   
-    
+{
     public $hideTitle       = true;
 
     public function init()
     {
-        
         $this->nameSingular = __('ActionCard', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('ActionCards', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Index-like cards with configurable FontAwesome icons and no excerpt.', CustomModuleHelper::DOMAIN);
-        
+
         $Module = CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
+
         add_filter('acf/fields/post_object/query/key=field_action-card', [$this, 'postObjectQuery'], 10, 3);
-        
     }
 
     public function data() : array
     {
-        
         $data = get_fields($this->ID);
-        
+
         $columnClass = 'grid-md-2';
 
-        if(!empty($data['action_columns']))
+        if (!empty($data['action_columns'])) {
             $columnClass = $data['action_columns'];
-        
+        }
+
         $data = array_replace($data, [
             'items' => $this->prepareItems($data['action-card']),
             'columnClass' => $columnClass,
@@ -43,7 +40,6 @@ class ActionCard extends \Modularity\Module
         ]);
 
         return $data;
-        
     }
 
     public function prepareItems($items)

--- a/custom-modules/ColoredIndex/ColoredIndex.php
+++ b/custom-modules/ColoredIndex/ColoredIndex.php
@@ -6,27 +6,23 @@ use \Simrishamn\Theme\CustomModuleHelper;
 
 class ColoredIndex extends \Modularity\Module
 {
-
     public function init()
     {
-        
         $this->nameSingular = __('Colored Index', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Colored Indices', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Outputs a colored index card text & customizable link to a page.', CustomModuleHelper::DOMAIN);
-        
+
         $Module = CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
     }
 
     public function data() : array
     {
-        
         $data = get_fields($this->ID);
-        
+
         $data = array_replace($data, [
             'items' => $data['colored-index'],
             'columnClass' => $data['index_columns'],
@@ -34,14 +30,11 @@ class ColoredIndex extends \Modularity\Module
         ]);
 
         return $data;
-        
     }
 
     public function template() : string
     {
-        
         return (get_field('format', $this->ID) == 'default') ? $this->slug . '.blade.php' : 'colored-info.blade.php';
-        
     }
 
     /**

--- a/custom-modules/InlayIndex/InlayIndex.php
+++ b/custom-modules/InlayIndex/InlayIndex.php
@@ -6,29 +6,25 @@ use \Simrishamn\Theme\CustomModuleHelper;
 
 class InlayIndex extends \Modularity\Module
 {
-
     public function init()
     {
-        
         $this->nameSingular = __('Inlay Index', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Inlay Indices', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Outputs 2-4 of the latest posts from the selected post-type.', CustomModuleHelper::DOMAIN);
-        
+
         $Module = CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
     }
 
     public function data() : array
     {
-      
         $data = get_fields($this->ID);
 
         $args = ['numberposts' => 2, 'post_type' => $data['post_types']];
-        
+
         $data = array_replace($data, [
             'items' => get_posts($args),
             'box_color' => $data['excerpt_box_color'],
@@ -36,7 +32,6 @@ class InlayIndex extends \Modularity\Module
         ]);
 
         return $data;
-        
     }
 
     /**

--- a/custom-modules/LinkList/LinkList.php
+++ b/custom-modules/LinkList/LinkList.php
@@ -6,39 +6,34 @@ use \Simrishamn\Theme\CustomModuleHelper;
 
 class LinkList extends \Modularity\Module
 {
-    
     public function init()
     {
-        
         $this->nameSingular = __('Link List', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Link Lists', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Outputs a list of links, with option to choose color.', CustomModuleHelper::DOMAIN);
-        
+
         $Module = CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
+
         // Already registered slug & fields as "linklist", breaks if changed to correct kebab-case
         $this->slug     = 'linklist';
         $this->fields   = CustomModuleHelper::fields(CustomModuleHelper::moduleName($this), 'linklist');
 
         include_once $this->fields;
-        
     }
 
     public function data() : array
     {
-        
         $data = get_fields($this->ID);
 
         $data = array_replace($data, [
             'classes' => CustomModuleHelper::classes(['box', 'box-panel'], $this)
         ]);
-        
+
         return $data;
-        
     }
 
   /**

--- a/custom-modules/NewsList/NewsList.php
+++ b/custom-modules/NewsList/NewsList.php
@@ -6,25 +6,21 @@ use \Simrishamn\Theme\CustomModuleHelper;
 
 class NewsList extends \Modularity\Module
 {
-    
     public function init()
     {
-        
         $this->nameSingular = __('News', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('News', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Outputs a number of featured and latests posts in a grid- or list manner.', CustomModuleHelper::DOMAIN);
 
         $Module = CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
     }
 
     public function data() : array
     {
-        
         $data = get_fields($this->ID);
 
         $args = [
@@ -36,19 +32,18 @@ class NewsList extends \Modularity\Module
             'post_type' => 'post',
             'category' => $data['category']
         ];
-        
+
         $data = array_replace($data, [
             'featured' => [$data['featured_one'], $data['featured_two']],
             'items' => get_posts($args),
             'columnClass' => $columnClass,
             'classes' => CustomModuleHelper::classes(['box', 'box-panel'], $this)
         ]);
-        
+
         $this->setMetaData($data['items'], 150);
         $this->setMetaData($data['featured']);
 
         return $data;
-        
     }
 
     public function setMetaData($items, $excerpt_length = 270)
@@ -74,9 +69,7 @@ class NewsList extends \Modularity\Module
 
     public function template()
     {
-        
         return (get_field('format', $this->ID) == 'default') ? $this->slug . '.blade.php' : 'news-grid.blade.php';
-
     }
 
     /**

--- a/custom-modules/Teaser/Teaser.php
+++ b/custom-modules/Teaser/Teaser.php
@@ -6,27 +6,23 @@ use \Simrishamn\Theme\CustomModuleHelper;
 
 class Teaser extends \Modularity\Module
 {
-
     public function init()
     {
-        
         $this->nameSingular = __('Teaser Block', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Teaser Blocks', CustomModuleHelper::DOMAIN);
         $this->namePlural   = __('Outputs a Teaser Block with lead text, image & customizable link to a page.', CustomModuleHelper::DOMAIN);
-        
+
         $Module = \Simrishamn\Theme\CustomModuleHelper::setModule($this);
-        
+
         foreach ($Module as $key => $val) {
             $this->{$key} = $val;
         }
-        
     }
 
     public function data() : array
     {
-        
         $data = get_fields($this->ID);
-        
+
         $data = array_replace($data, [
             'items' => $data['teaser'],
             'columnClass' => $data['index_columns'],
@@ -34,7 +30,6 @@ class Teaser extends \Modularity\Module
         ]);
 
         return $data;
-        
     }
 
     /**

--- a/library/Theme/CustomModuleHelper.php
+++ b/library/Theme/CustomModuleHelper.php
@@ -4,69 +4,66 @@ namespace Simrishamn\Theme;
 
 class CustomModuleHelper
 {
-    
     const DOMAIN        = 'simrishamn';
     const MODULE_FOLDER = SIMRISHAMN_PATH . '/custom-modules/';
-    
+
     /**
      * Initialize the Module
      *
      * @param object $object Current Class object
      * @return object The module settings
      */
-    public static function setModule ($object) : object
+    public static function setModule($object) : object
     {
-        
-        if (!$object)
+        if (!$object) {
             throw new \Exception('No object was found.');
-        
+        }
+
         $obj = new \stdClass();
-        
+
         $obj->moduleName    = self::moduleName($object);
-        
+
         $obj->slug          = self::kebabcase($obj->moduleName);
         $obj->fields        = self::fields($obj->moduleName);
-        
-        if (file_exists($obj->fields))
+
+        if (file_exists($obj->fields)) {
             include_once $obj->fields;
-        
+        }
+
         return $obj;
-        
     }
-    
+
     /**
      * Current Class name
      *
      * @param string $object Current Class object
      * @return string The module name
      */
-    public static function moduleName ($object) : string
+    public static function moduleName($object) : string
     {
-        
         return (new \ReflectionClass($object))->getShortName();
-        
     }
-    
+
     /**
      * Creates a slugified kebabcase string
      *
      * @param string $string The string to be converted
      * @return string The converted string
      */
-    public static function kebabcase ($string) : string
+    public static function kebabcase($string) : string
     {
-        
         $string = strip_tags($string);
-        
+
         $string = preg_replace('~[^\pL\d]+~u', '-', $string);
-        
+
         setlocale(LC_MONETARY, get_locale());
-        
+
         $locale = localeconv();
-        
-        if ($locale['int_curr_symbol'] == "")
+
+        if ($locale['int_curr_symbol'] == "") {
             setlocale(LC_MONETARY, 'sv_SE.utf8');
-        
+        }
+
         $string = iconv('utf-8', 'us-ascii//TRANSLIT', $string);
 
         $string = preg_replace('~[^-\w]+~', '', $string);
@@ -74,18 +71,18 @@ class CustomModuleHelper
         $string = trim($string, '-');
 
         $string = preg_replace('~-+~', '-', $string);
-        
+
         $string = preg_replace(['/([a-z\d])([A-Z])/', '/([^-])([A-Z][a-z])/'], '$1-$2', $string);
-        
+
         $string = strtolower($string);
 
-        if (empty($string))
+        if (empty($string)) {
             throw new \Exception('No slug was set.');
-        
+        }
+
         return $string;
-        
     }
-    
+
     /**
      * The full url to the fields php-file
      *
@@ -93,18 +90,17 @@ class CustomModuleHelper
      * @param mixed $customModuleName Set custom filename, always prefixed with mod-
      * @return string The php-file url
      */
-    public static function fields ($moduleName, $customModuleModName = false) : string
+    public static function fields($moduleName, $customModuleModName = false) : string
     {
-        
-        if($customModuleModName)
+        if ($customModuleModName) {
             $moduleModName = $customModuleModName;
-        else
+        } else {
             $moduleModName = self::kebabcase($moduleName);
-        
+        }
+
         return self::MODULE_FOLDER . $moduleName . '/acf/php/mod-' . $moduleModName . '.php';
-        
     }
-    
+
     /**
      * Module classes
      *
@@ -112,11 +108,8 @@ class CustomModuleHelper
      * @param object $object Current Class object
      * @return string The classes in a string
      */
-    public static function classes ($classes, $object) : string
+    public static function classes($classes, $object) : string
     {
-        
         return implode(' ', apply_filters('Modularity/Module/Classes', $classes, $object->post_type, $object->args));
-        
     }
-    
 }

--- a/library/Theme/Style.php
+++ b/library/Theme/Style.php
@@ -23,12 +23,10 @@ class Style
      */
     public function isSubsite($classes)
     {
-        if(!is_main_site()) {
-
+        if (!is_main_site()) {
             $subsiteName = sanitize_title(get_option('blogname'));
 
             array_push($classes, 'is-subsite', $subsiteName);
-
         }
         return $classes;
     }


### PR DESCRIPTION
Automatic (mostly) linter fixes via `phpcbf`:

- https://www.php-fig.org/psr/psr-2/#43-methods - "There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis."
- https://www.php-fig.org/psr/psr-2/#5-control-structures - "The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body."

Plus removal of trailing whitespace.

Thoughts?