### PR TITLE
SIEW-312 Fixed post_type returning false

### DIFF
--- a/custom-modules/InlayIndex/InlayIndex.php
+++ b/custom-modules/InlayIndex/InlayIndex.php
@@ -27,6 +27,7 @@ class InlayIndex extends \Modularity\Module
 
         $data = array_replace($data, [
             'items' => get_posts($args),
+            'post_type' => $data['post_types'],
             'box_color' => $data['excerpt_box_color'],
             'classes' => 'box box-panel'
         ]);


### PR DESCRIPTION
Fixed issue where `get_post_type_archive_link()` returned false looking for `$post_type`.