### PR TITLE
Update Laravel Mix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
     "presets": [
-        "env"
+        "@babel/preset-env"
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .projectile
-mix-manifest.json
 package-lock.json
 node_modules
 assets/dist

--- a/assets/source/js/theme.js
+++ b/assets/source/js/theme.js
@@ -1,4 +1,6 @@
-import 'babel-polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import './content/header';
 import Helpers from './theme/helpers';
 

--- a/package.json
+++ b/package.json
@@ -12,15 +12,20 @@
     "eslint": "node_modules/.bin/eslint assets/source/js"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0"
+    "core-js": "^3.0.0",
+    "regenerator-runtime": "^0.13.2"
   },
   "devDependencies": {
-    "babel-preset-env": "^1.7.0",
-    "compression-webpack-plugin": "^1.1.12",
-    "eslint": "^5.8.0",
+    "@babel/core": "^7.4.0",
+    "@babel/preset-env": "^7.4.2",
+    "compression-webpack-plugin": "^2.0.0",
+    "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.14.0",
-    "laravel-mix": "^2.1.14",
-    "sass-lint": "^1.12.1"
+    "eslint-plugin-import": "^2.16.0",
+    "laravel-mix": "^4.0.15",
+    "sass": "^1.17.3",
+    "sass-lint": "^1.12.1",
+    "sass-loader": "^7.1.0",
+    "vue-template-compiler": "^2.6.10"
   }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -3,7 +3,7 @@ const Mix = require('laravel-mix');
 
 const options = {
     clearConsole: false,
-    processCssUrls: false
+    processCssUrls: false,
 };
 
 const config = {
@@ -11,16 +11,20 @@ const config = {
         new Compression({
             include: /\/dist\//,
             test: /\.(js|css)$/,
-            asset: '[path][query]',
+            filename: '[path][query]',
         }),
     ],
 };
 
-Mix.options(options).webpackConfig(config)
-   .js('assets/source/js/admin.js', 'assets/dist/js')
-   .js('assets/source/js/editor.js', 'assets/dist/js')
-   .js('assets/source/js/theme.js', 'assets/dist/js')
-   .sass('assets/source/sass/admin.scss', 'assets/dist/css')
-   .sass('assets/source/sass/editor.scss', 'assets/dist/css')
-   .sass('assets/source/sass/theme.scss', 'assets/dist/css')
-   .sourceMaps();
+Mix
+    .js('assets/source/js/admin.js', 'js')
+    .js('assets/source/js/editor.js', 'js')
+    .js('assets/source/js/theme.js', 'js')
+    .sass('assets/source/sass/admin.scss', 'css')
+    .sass('assets/source/sass/editor.scss', 'css')
+    .sass('assets/source/sass/theme.scss', 'css')
+    .setPublicPath('assets/dist')
+    .webpackConfig(config)
+    .options(options)
+    .sourceMaps()
+    .version();


### PR DESCRIPTION
Updates Laravel Mix to the latest version.

- Migrate to the new way of specifying the Babel presets.
- Replace Babel Polyfill with Core JS, since Babel Polyfill is deprecated.
- Laravel Mix automatically adds some dependencies to `package.json` now.
- Enable cache busting for the build. We should start referencing these in the backend too.

We should make sure to test this in an older browser.