### PR TITLE
NOJIRA Fix tag builds in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ before_build:
   - 'PROJECT="$(composer config name)"'
   - 'TAG="$(git describe --match="[0-9]*" --abbrev=0)"'
   - 'BUILD="$TAG.$APPVEYOR_BUILD_NUMBER"'
-  - 'SUFFIX="$(test -z $APPVEYOR_REPO_TAG_NAME && echo "-dev")"'
+  - 'SUFFIX="$(test -z $APPVEYOR_REPO_TAG_NAME && echo "-dev" || true)"'
   - 'VERSION="${APPVEYOR_REPO_TAG_NAME:-$BUILD}${SUFFIX}"'
   - 'ARTIFACT="$(slugify $PROJECT $VERSION).zip"'
 


### PR DESCRIPTION
Setting the SUFFIX environment variable would fail for tag builds since
the expression evaluated to false. This commit makes it so that the
expression evaluates to true while keeping the variable empty.