### PR TITLE
NOJIRA Fixes error when footer is empty

### DIFF
--- a/library/Theme/Template.php
+++ b/library/Theme/Template.php
@@ -171,6 +171,10 @@ class Template
      */
     public function removeEmptyValuesFooter($data) : array
     {
+        if (!$data) {
+            return [];
+        }
+        
         foreach ($data as $type => &$array) {
             if ($type == 'links') {
                 continue;


### PR DESCRIPTION
Would cause an error when `$data` is empty, for example on new subsites