### PR TITLE
SIEW-337 Make Helper shortText method to use multi-byte safe substr

### DIFF
--- a/library/Theme/Helper.php
+++ b/library/Theme/Helper.php
@@ -17,7 +17,7 @@ class Helper
     public static function shortText($text, $len, $ellipsis = true)
     {
         if (strlen($text) > $len) {
-            $text = rtrim(substr($text, 0, $len));
+            $text = rtrim(mb_substr($text, 0, $len));
             return $text . ($ellipsis ? '...' : '');
         }
         return $text;


### PR DESCRIPTION
Fixes an issue where excerpt previews won't show at all if the word at the limit of the substring contains special characters.