### PR TITLE
SIEW-367: Add template override for search

### DIFF
--- a/assets/source/sass/layout/_header.scss
+++ b/assets/source/sass/layout/_header.scss
@@ -43,7 +43,7 @@ header#site-header {
 
         .widget_text {
             text-transform: uppercase;
-            
+
             h3 {
                 font-size: 19px;
                 line-height: 24px;

--- a/assets/source/sass/subsites/naringslivsutveckling/_header.scss
+++ b/assets/source/sass/subsites/naringslivsutveckling/_header.scss
@@ -15,7 +15,7 @@ header {
                 background:url('./../../images/subsites/naringslivsutveckling/header-naringslivsutveckling.png') no-repeat bottom center;
                 background-size:cover;
             }
-        
+
             &.customizer-header-primary {
                 background-color: #b1cb34;
             }

--- a/assets/source/sass/subsites/simrishamnsbostader/_header.scss
+++ b/assets/source/sass/subsites/simrishamnsbostader/_header.scss
@@ -15,7 +15,7 @@ header {
                 background:url('./../../images/subsites/simrishamnsbostader/sinab-header.png') no-repeat bottom center;
                 background-size:cover;
             }
-        
+
             &.customizer-header-primary {
                 background-color: #666666;
 

--- a/bem-views/search.blade.php
+++ b/bem-views/search.blade.php
@@ -1,0 +1,19 @@
+@extends('templates.master')
+@section('content')
+    @switch($activeSearchEngine)
+        @case("google")
+            @include('partials.search.google')
+            @break
+        @case("algoliacustom")
+            @include('partials.search.algolia-customsearch')
+            @break
+        @case("algolia")
+            @include('partials.search.algolia')
+            @break
+        @case("algoliainstant")
+            @include('partials.search.algolia-instantsearch')
+            @break
+        @default
+            @include('partials.search.wp')
+    @endswitch
+@stop

--- a/bem-views/templates/master.blade.php
+++ b/bem-views/templates/master.blade.php
@@ -81,7 +81,7 @@
             @endif
         @show
 
-        @include('partials.translate-modal');
+        @include('partials.translate-modal')
 
         <main class="clearfix main-content" role="main">
             @yield('content')


### PR DESCRIPTION
This is the same as Municipio's template, except that it uses the `content` secition instead of `layout`. The `layout` section is missing from our master template. We should probably make our templates more similar to Municipio's in the future.

Either way, here's a quick fix.